### PR TITLE
upgrade to geth 1.10.1

### DIFF
--- a/helm-values/geth-swap.yaml
+++ b/helm-values/geth-swap.yaml
@@ -16,7 +16,7 @@ geth:
       period: 3
 image:
   repository: ethereum/client-go
-  tag: v1.9.25
+  tag: v1.10.1
   pullPolicy: IfNotPresent
 resources:
   limits:


### PR DESCRIPTION
bee has been fixed to also work with newer geths. the new version will also allow integration testing to run with berlin-fork enabled.